### PR TITLE
Fix uppercase github usernames causing error when tagging images

### DIFF
--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+GITHUB_USER="$(echo "$GITHUB_USER" | tr '[:upper:]' '[:lower:]')"
 BACKEND_IMAGE_NAME=ghcr.io/$GITHUB_USER/backend:latest
 FRONTEND_IMAGE_NAME=ghcr.io/$GITHUB_USER/frontend:latest
 


### PR DESCRIPTION
Images can't include upper case letters, therefore, the script fails with usernames containing said letters, like mine.
This PR fixes this by automatically converting the github usernames to lowercase only.